### PR TITLE
Add Shields.io badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)
+[![Lifecycle: Stable](https://img.shields.io/badge/Lifecycle-Stable-brightgreen)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#stable-)
+
 # Slack Archivist
 
 Your friendly Slack-to-Discourse archivist.


### PR DESCRIPTION
Added [community extension and lifecycle badges](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md) to the project README